### PR TITLE
MenuLink now has UseShellExecute

### DIFF
--- a/Common/Systems/MainMenuOverlays/MenuLink.cs
+++ b/Common/Systems/MainMenuOverlays/MenuLink.cs
@@ -16,6 +16,11 @@ namespace TerrariaOverhaul.Common.Systems.MainMenuOverlays
 			Url = url;
 		}
 
-		protected override void OnClicked() => Process.Start(Url);
+		protected override void OnClicked()
+		{
+			Process.Start(new ProcessStartInfo(Url) {
+				UseShellExecute = true
+			});
+		}
 	}
 }


### PR DESCRIPTION
Before, it would immediately crash tModLoader because the 'file' would not exist. Now it doesn't crash.