### PR TITLE
Prevent hook "drifting" while moving horizontally

### DIFF
--- a/Common/ModEntities/Projectiles/ProjectileGrapplingHookPhysics.cs
+++ b/Common/ModEntities/Projectiles/ProjectileGrapplingHookPhysics.cs
@@ -169,19 +169,26 @@ namespace TerrariaOverhaul.Common.ModEntities.Projectiles
 
 			player.GoingDownWithGrapple = pull && dir.Y < 0f;
 
-			float dist = Vector2.Distance(playerCenter, projCenter);
+			// Prevent hooks from going farther than normal
+			float ClampDistance(float distance)
+				=> MathHelper.Clamp(distance, 0f, hookRange - 1f);
+
+			float dist = ClampDistance(Vector2.Distance(playerCenter, projCenter));
 			bool down = player.controlDown && maxDist < hookRange;
 			bool up = player.controlUp;
 
-			if (pull || ((up || down) && up != down)) {
-				dist += pull ? -12.5f : up ? -5f : 5f;
-				dist = MathHelper.Clamp(dist, 10f, hookRange - 32f);
-				maxDist = dist;
-				player.velocity *= pull ? 0.1f : up ? 0.975f : 1f;
-			}
+			const float PullSpeed = 12.5f;
+			const float PullVelocity = 0.1f;
+			const float RaiseSpeed = 5f;
+			const float RaiseVelocity = 0.975f;
+			const float LowerSpeed = 5f;
+			const float LowerVelocity = 1f;
 
-			// Prevent hook from going farther than normal by clamping again
-			dist = MathHelper.Clamp(dist, 10f, hookRange - 32f);
+			if (pull || ((up || down) && up != down)) {
+				maxDist = dist = ClampDistance(dist + (pull ? -PullSpeed : up ? -RaiseSpeed : LowerSpeed));
+
+				player.velocity *= pull ? PullVelocity : (up ? RaiseVelocity : LowerVelocity);
+			}
 
 			float nextDistance = Vector2.Distance(playerCenter + player.velocity, projCenter);
 			float deltaDistance = nextDistance - dist;

--- a/Common/ModEntities/Projectiles/ProjectileGrapplingHookPhysics.cs
+++ b/Common/ModEntities/Projectiles/ProjectileGrapplingHookPhysics.cs
@@ -180,6 +180,9 @@ namespace TerrariaOverhaul.Common.ModEntities.Projectiles
 				player.velocity *= pull ? 0.1f : up ? 0.975f : 1f;
 			}
 
+			// Prevent hook from going farther than normal by clamping again
+			dist = MathHelper.Clamp(dist, 10f, hookRange - 32f);
+
 			float nextDistance = Vector2.Distance(playerCenter + player.velocity, projCenter);
 			float deltaDistance = nextDistance - dist;
 			var vect = projCenter - playerCenter;


### PR DESCRIPTION
Currently, if you hook, extend it to max length, and then move horizontally, the hook's length will slowly become larger than its max length (I assume because it's not clamped if you're not moving up or down). This is a simple one-line fix that clamps it regardless of whether you're extending or retracting.

Before: https://streamable.com/nwcydg

After: https://streamable.com/eqldvt

If there's a different way you'd like this styled, feel free to edit obviously; I couldn't think of a more elegant way to fit it in