### PR TITLE
power attack config

### DIFF
--- a/Common/Melee/_Overhauls/Axe.cs
+++ b/Common/Melee/_Overhauls/Axe.cs
@@ -19,6 +19,8 @@ namespace TerrariaOverhaul.Common.Melee
 			PitchVariance = 0.1f,
 		};
 
+		public static readonly ConfigEntry<bool> EnableAxePowerAttack = new(ConfigSide.Both, "Melee", nameof(EnableAxePowerAttack), () => true);
+
 		public override bool ShouldApplyItemOverhaul(Item item)
 		{
 			// Must have woodcutting capabilities
@@ -61,6 +63,8 @@ namespace TerrariaOverhaul.Common.Melee
 				c.AnimateLegs = true;
 			});
 
+			if(EnableAxePowerAttack)
+			{
 			// Power Attacks
 			item.EnableComponent<ItemMeleePowerAttackEffects>();
 			item.EnableComponent<ItemPowerAttacks>(c => {
@@ -76,6 +80,7 @@ namespace TerrariaOverhaul.Common.Melee
 					c.Sound = AxeChargedSwingSound;
 					c.ReplacesUseSound = true;
 				});
+			}
 			}
 		}
 	}

--- a/Common/Melee/_Overhauls/Axe.cs
+++ b/Common/Melee/_Overhauls/Axe.cs
@@ -4,6 +4,7 @@ using Terraria.ID;
 using Terraria.ModLoader;
 using TerrariaOverhaul.Common.BloodAndGore;
 using TerrariaOverhaul.Common.Charging;
+using TerrariaOverhaul.Core.Configuration;
 using TerrariaOverhaul.Core.ItemComponents;
 using TerrariaOverhaul.Core.ItemOverhauls;
 
@@ -19,7 +20,7 @@ namespace TerrariaOverhaul.Common.Melee
 			PitchVariance = 0.1f,
 		};
 
-		public static readonly ConfigEntry<bool> EnableAxePowerAttack = new(ConfigSide.Both, "Melee", nameof(EnableAxePowerAttack), () => true);
+		public static readonly ConfigEntry<bool> EnableAxePowerAttacks = new(ConfigSide.Both, "Melee", nameof(EnableAxePowerAttacks), () => true);
 
 		public override bool ShouldApplyItemOverhaul(Item item)
 		{
@@ -63,24 +64,23 @@ namespace TerrariaOverhaul.Common.Melee
 				c.AnimateLegs = true;
 			});
 
-			if(EnableAxePowerAttack)
-			{
 			// Power Attacks
-			item.EnableComponent<ItemMeleePowerAttackEffects>();
-			item.EnableComponent<ItemPowerAttacks>(c => {
-				c.ChargeLengthMultiplier = 1.5f;
-				c.CommonStatMultipliers.MeleeRangeMultiplier = 1.4f;
-				c.CommonStatMultipliers.MeleeDamageMultiplier = c.CommonStatMultipliers.ProjectileDamageMultiplier = 1.5f;
-				c.CommonStatMultipliers.MeleeKnockbackMultiplier = c.CommonStatMultipliers.ProjectileKnockbackMultiplier = 1.5f;
-				c.CommonStatMultipliers.ProjectileSpeedMultiplier = 1.5f;
-			});
-
-			if (!Main.dedServ) {
-				item.EnableComponent<ItemPowerAttackSounds>(c => {
-					c.Sound = AxeChargedSwingSound;
-					c.ReplacesUseSound = true;
+			if (EnableAxePowerAttacks) {
+				item.EnableComponent<ItemMeleePowerAttackEffects>();
+				item.EnableComponent<ItemPowerAttacks>(c => {
+					c.ChargeLengthMultiplier = 1.5f;
+					c.CommonStatMultipliers.MeleeRangeMultiplier = 1.4f;
+					c.CommonStatMultipliers.MeleeDamageMultiplier = c.CommonStatMultipliers.ProjectileDamageMultiplier = 1.5f;
+					c.CommonStatMultipliers.MeleeKnockbackMultiplier = c.CommonStatMultipliers.ProjectileKnockbackMultiplier = 1.5f;
+					c.CommonStatMultipliers.ProjectileSpeedMultiplier = 1.5f;
 				});
-			}
+
+				if (!Main.dedServ) {
+					item.EnableComponent<ItemPowerAttackSounds>(c => {
+						c.Sound = AxeChargedSwingSound;
+						c.ReplacesUseSound = true;
+					});
+				}
 			}
 		}
 	}

--- a/Common/Melee/_Overhauls/Broadsword.cs
+++ b/Common/Melee/_Overhauls/Broadsword.cs
@@ -12,9 +12,11 @@ using TerrariaOverhaul.Common.Hooks.Items;
 using TerrariaOverhaul.Core.ItemComponents;
 using TerrariaOverhaul.Core.ItemOverhauls;
 using TerrariaOverhaul.Utilities;
+using TerrariaOverhaul.Core.Configuration;
 
 namespace TerrariaOverhaul.Common.Melee
 {
+	
 	public partial class Broadsword : ItemOverhaul, ICanDoMeleeDamage, IModifyItemNPCHitSound
 	{
 		public static readonly SoundStyle SwordMediumSwing = new($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Items/Melee/CuttingSwingMedium", 2) {
@@ -28,6 +30,8 @@ namespace TerrariaOverhaul.Common.Melee
 			Volume = 0.65f,
 			PitchVariance = 0.1f
 		};
+		
+		public static readonly ConfigEntry<bool> EnablePowerAttack = new(ConfigSide.Both, "Melee", nameof(EnablePowerAttack), () => true);
 
 		public override bool ShouldApplyItemOverhaul(Item item)
 		{
@@ -73,6 +77,9 @@ namespace TerrariaOverhaul.Common.Melee
 			});
 
 			// Power Attacks
+			
+			if(EnablePowerAttack)
+			{
 			item.EnableComponent<ItemMeleePowerAttackEffects>();
 			item.EnableComponent<ItemPowerAttacks>(c => {
 				c.ChargeLengthMultiplier = 1.5f;
@@ -88,6 +95,8 @@ namespace TerrariaOverhaul.Common.Melee
 					c.ReplacesUseSound = true;
 				});
 			}
+			}
+
 
 			// Killing Blows
 			item.EnableComponent<ItemKillingBlows>();

--- a/Common/Melee/_Overhauls/Broadsword.cs
+++ b/Common/Melee/_Overhauls/Broadsword.cs
@@ -31,7 +31,7 @@ namespace TerrariaOverhaul.Common.Melee
 			PitchVariance = 0.1f
 		};
 		
-		public static readonly ConfigEntry<bool> EnablePowerAttack = new(ConfigSide.Both, "Melee", nameof(EnablePowerAttack), () => true);
+		public static readonly ConfigEntry<bool> EnableSwordPowerAttack = new(ConfigSide.Both, "Melee", nameof(EnableSwordPowerAttack), () => true);
 
 		public override bool ShouldApplyItemOverhaul(Item item)
 		{
@@ -78,7 +78,7 @@ namespace TerrariaOverhaul.Common.Melee
 
 			// Power Attacks
 			
-			if(EnablePowerAttack)
+			if(EnableSwordPowerAttack)
 			{
 			item.EnableComponent<ItemMeleePowerAttackEffects>();
 			item.EnableComponent<ItemPowerAttacks>(c => {

--- a/Common/Melee/_Overhauls/Broadsword.cs
+++ b/Common/Melee/_Overhauls/Broadsword.cs
@@ -9,14 +9,14 @@ using TerrariaOverhaul.Common.BloodAndGore;
 using TerrariaOverhaul.Common.Camera;
 using TerrariaOverhaul.Common.Charging;
 using TerrariaOverhaul.Common.Hooks.Items;
+using TerrariaOverhaul.Core.Configuration;
 using TerrariaOverhaul.Core.ItemComponents;
 using TerrariaOverhaul.Core.ItemOverhauls;
 using TerrariaOverhaul.Utilities;
-using TerrariaOverhaul.Core.Configuration;
 
 namespace TerrariaOverhaul.Common.Melee
 {
-	
+
 	public partial class Broadsword : ItemOverhaul, ICanDoMeleeDamage, IModifyItemNPCHitSound
 	{
 		public static readonly SoundStyle SwordMediumSwing = new($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Items/Melee/CuttingSwingMedium", 2) {
@@ -31,7 +31,7 @@ namespace TerrariaOverhaul.Common.Melee
 			PitchVariance = 0.1f
 		};
 		
-		public static readonly ConfigEntry<bool> EnableSwordPowerAttack = new(ConfigSide.Both, "Melee", nameof(EnableSwordPowerAttack), () => true);
+		public static readonly ConfigEntry<bool> EnableBroadswordPowerAttacks = new(ConfigSide.Both, "Melee", nameof(EnableBroadswordPowerAttacks), () => true);
 
 		public override bool ShouldApplyItemOverhaul(Item item)
 		{
@@ -77,26 +77,23 @@ namespace TerrariaOverhaul.Common.Melee
 			});
 
 			// Power Attacks
-			
-			if(EnableSwordPowerAttack)
-			{
-			item.EnableComponent<ItemMeleePowerAttackEffects>();
-			item.EnableComponent<ItemPowerAttacks>(c => {
-				c.ChargeLengthMultiplier = 1.5f;
-				c.CommonStatMultipliers.MeleeRangeMultiplier = 1.4f;
-				c.CommonStatMultipliers.MeleeDamageMultiplier = c.CommonStatMultipliers.ProjectileDamageMultiplier = 1.5f;
-				c.CommonStatMultipliers.MeleeKnockbackMultiplier = c.CommonStatMultipliers.ProjectileKnockbackMultiplier = 1.5f;
-				c.CommonStatMultipliers.ProjectileSpeedMultiplier = 1.5f;
-			});
-
-			if (!Main.dedServ) {
-				item.EnableComponent<ItemPowerAttackSounds>(c => {
-					c.Sound = SwordHeavySwing;
-					c.ReplacesUseSound = true;
+			if (EnableBroadswordPowerAttacks) {
+				item.EnableComponent<ItemMeleePowerAttackEffects>();
+				item.EnableComponent<ItemPowerAttacks>(c => {
+					c.ChargeLengthMultiplier = 1.5f;
+					c.CommonStatMultipliers.MeleeRangeMultiplier = 1.4f;
+					c.CommonStatMultipliers.MeleeDamageMultiplier = c.CommonStatMultipliers.ProjectileDamageMultiplier = 1.5f;
+					c.CommonStatMultipliers.MeleeKnockbackMultiplier = c.CommonStatMultipliers.ProjectileKnockbackMultiplier = 1.5f;
+					c.CommonStatMultipliers.ProjectileSpeedMultiplier = 1.5f;
 				});
-			}
-			}
 
+				if (!Main.dedServ) {
+					item.EnableComponent<ItemPowerAttackSounds>(c => {
+						c.Sound = SwordHeavySwing;
+						c.ReplacesUseSound = true;
+					});
+				}
+			}
 
 			// Killing Blows
 			item.EnableComponent<ItemKillingBlows>();

--- a/Common/Melee/_Overhauls/Hammer.cs
+++ b/Common/Melee/_Overhauls/Hammer.cs
@@ -19,6 +19,8 @@ namespace TerrariaOverhaul.Common.Melee
 			PitchVariance = 0.1f,
 		};
 
+		public static readonly ConfigEntry<bool> EnableHammerPowerAttack = new(ConfigSide.Both, "Melee", nameof(EnableHammerPowerAttack), () => true);
+
 		public override bool ShouldApplyItemOverhaul(Item item)
 		{
 			// Must have hammering capabilities
@@ -62,6 +64,8 @@ namespace TerrariaOverhaul.Common.Melee
 				c.AnimateLegs = true;
 			});
 
+			if(EnableHammerPowerAttack)
+			{
 			// Power Attacks
 			item.EnableComponent<ItemMeleePowerAttackEffects>();
 			item.EnableComponent<ItemPowerAttacks>(c => {
@@ -77,6 +81,7 @@ namespace TerrariaOverhaul.Common.Melee
 					c.Sound = HammerChargedSwing;
 					c.ReplacesUseSound = true;
 				});
+			}
 			}
 		}
 	}

--- a/Common/Melee/_Overhauls/Hammer.cs
+++ b/Common/Melee/_Overhauls/Hammer.cs
@@ -3,6 +3,7 @@ using Terraria.Audio;
 using Terraria.ID;
 using TerrariaOverhaul.Common.BloodAndGore;
 using TerrariaOverhaul.Common.Charging;
+using TerrariaOverhaul.Core.Configuration;
 using TerrariaOverhaul.Core.ItemComponents;
 using TerrariaOverhaul.Core.ItemOverhauls;
 
@@ -19,7 +20,7 @@ namespace TerrariaOverhaul.Common.Melee
 			PitchVariance = 0.1f,
 		};
 
-		public static readonly ConfigEntry<bool> EnableHammerPowerAttack = new(ConfigSide.Both, "Melee", nameof(EnableHammerPowerAttack), () => true);
+		public static readonly ConfigEntry<bool> EnableHammerPowerAttacks = new(ConfigSide.Both, "Melee", nameof(EnableHammerPowerAttacks), () => true);
 
 		public override bool ShouldApplyItemOverhaul(Item item)
 		{
@@ -64,24 +65,23 @@ namespace TerrariaOverhaul.Common.Melee
 				c.AnimateLegs = true;
 			});
 
-			if(EnableHammerPowerAttack)
-			{
 			// Power Attacks
-			item.EnableComponent<ItemMeleePowerAttackEffects>();
-			item.EnableComponent<ItemPowerAttacks>(c => {
-				c.ChargeLengthMultiplier = 1.5f;
-				c.CommonStatMultipliers.MeleeRangeMultiplier = 1.4f;
-				c.CommonStatMultipliers.MeleeDamageMultiplier = c.CommonStatMultipliers.ProjectileDamageMultiplier = 1.5f;
-				c.CommonStatMultipliers.MeleeKnockbackMultiplier = c.CommonStatMultipliers.ProjectileKnockbackMultiplier = 2.0f; // Even more knockback
-				c.CommonStatMultipliers.ProjectileSpeedMultiplier = 1.5f;
-			});
-
-			if (!Main.dedServ) {
-				item.EnableComponent<ItemPowerAttackSounds>(c => {
-					c.Sound = HammerChargedSwing;
-					c.ReplacesUseSound = true;
+			if (EnableHammerPowerAttacks) {
+				item.EnableComponent<ItemMeleePowerAttackEffects>();
+				item.EnableComponent<ItemPowerAttacks>(c => {
+					c.ChargeLengthMultiplier = 1.5f;
+					c.CommonStatMultipliers.MeleeRangeMultiplier = 1.4f;
+					c.CommonStatMultipliers.MeleeDamageMultiplier = c.CommonStatMultipliers.ProjectileDamageMultiplier = 1.5f;
+					c.CommonStatMultipliers.MeleeKnockbackMultiplier = c.CommonStatMultipliers.ProjectileKnockbackMultiplier = 2.0f; // Even more knockback
+					c.CommonStatMultipliers.ProjectileSpeedMultiplier = 1.5f;
 				});
-			}
+
+				if (!Main.dedServ) {
+					item.EnableComponent<ItemPowerAttackSounds>(c => {
+						c.Sound = HammerChargedSwing;
+						c.ReplacesUseSound = true;
+					});
+				}
 			}
 		}
 	}


### PR DESCRIPTION
config for whether power attacks should be enabled or disabled outright for broadswords, axes, and hammers. To increase compatibility with other mods that add right click functionality to these weapon types.
