### PR TITLE
Small fix for player rotation while mounting.

### DIFF
--- a/Common/PlayerEffects/PlayerBodyRotation.cs
+++ b/Common/PlayerEffects/PlayerBodyRotation.cs
@@ -56,6 +56,9 @@ public sealed class PlayerBodyRotation : ModPlayer
 		if (!Player.mount.Active) {
 			Player.fullRotation = Rotation * Player.gravDir;
 		}
+		if (Player.mount.Active && !Player.mount.CanFly() && Player.OnGround()) {
+			Player.fullRotation = 0f;
+		}
 
 		Rotation = 0f;
 		RotationOffsetScale = 1f;


### PR DESCRIPTION
For some time, enabling "EnablePlayerTilting" option resulted some silly visual glitches while using some ground-based mount.
Example:
![example no 1](https://cdn.discordapp.com/attachments/513919978089742349/1006047506288885780/dotnet_1659928936_1366x768.png)

![example no 2](https://cdn.discordapp.com/attachments/513919978089742349/1006047505961721906/dotnet_1659928947_1366x768.png)

[example video](https://cdn.discordapp.com/attachments/513919978089742349/1006047949941395456/before.webm)

Now, after some trial and error, the end result looking [like this](https://cdn.discordapp.com/attachments/513919978089742349/1006047949131886662/after.webm).