### PR TITLE
Possibly a fix to #210

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### Changes
 - Fighter AI enemies will no longer leap at their targets if they're not facing them.
 - Dodgerolls can now be activated during an active item use animation or cooldown if the player is past its damage-dealing timeframe, and if at least `20 ticks` (third of a second) have passed since the item usage was initiated. Feedback is welcome!
+	(PR [#221](https://github.com/Mirsario/TerrariaOverhaul/pull/173) by **TimeSignMaid**)
 - Enqueued dodgerolls will now prevent automatic weapons from being re-used, no longer requiring a release of the use button to trigger a dodge.
 ### Fixes
 - Fixed a few broken keys in Italian localization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Changes
 - Fighter AI enemies will no longer leap at their targets if they're not facing them.
+- Dodgerolls can now be activated during an active item use animation or cooldown if the player is past its damage-dealing timeframe, and if at least `20 ticks` (third of a second) have passed since the item usage was initiated. Feedback is welcome!
 - Enqueued dodgerolls will now prevent automatic weapons from being re-used, no longer requiring a release of the use button to trigger a dodge.
 ### Fixes
 - Fixed a few broken keys in Italian localization.

--- a/Common/Dodgerolls/PlayerDodgerolls.cs
+++ b/Common/Dodgerolls/PlayerDodgerolls.cs
@@ -16,6 +16,7 @@ using TerrariaOverhaul.Core.Networking;
 using TerrariaOverhaul.Core.Time;
 using TerrariaOverhaul.Utilities;
 using TerrariaOverhaul.Common.Hooks.Items;
+using TerrariaOverhaul.Common.Items;
 
 #pragma warning disable IDE0060 // Remove unused parameter
 
@@ -94,7 +95,6 @@ public sealed class PlayerDodgerolls : ModPlayer
 		return true;
 	}
 
-	// CanX
 	public override bool CanUseItem(Item item)
 	{
 		// Disallow item use during a dodgeroll;
@@ -172,7 +172,9 @@ public sealed class PlayerDodgerolls : ModPlayer
 
 			// Handle item use
 			if (Player.ItemAnimationActive && Player.HeldItem is Item heldItem) {
-				int timeSinceItemUseStart = Player.itemAnimationMax - Player.itemAnimation;
+				uint timeSinceItemUseStart = !Player.TryGetModPlayer(out PlayerItemUse playerItemUse)
+					? (uint)Math.Max(0, Player.itemAnimationMax - Player.itemAnimation)
+					: playerItemUse.TimeSinceLastUseAnimation;
 
 				// Enforce a minimal commitment timeframe.
 				if (timeSinceItemUseStart < MinItemUseCommitment) {

--- a/Common/Dodgerolls/PlayerDodgerolls.cs
+++ b/Common/Dodgerolls/PlayerDodgerolls.cs
@@ -152,10 +152,15 @@ public sealed class PlayerDodgerolls : ModPlayer
 			}
 
 			// Don't allow dodging on mounts and during item use.
-			if (Player.mount != null && Player.mount.Active || Player.itemAnimation > 0) {
+			if (Player.mount != null && Player.mount.Active) {
 				return false;
 			}
 		}
+
+		if (Player.ItemAnimationActive) {
+			Player.channel = false;
+		}
+
 
 		DodgeAttemptTimer = 0;
 


### PR DESCRIPTION
Resolves #210.
https://docs.tmodloader.net/docs/stable/class_item.html , especially the "channel" attibute hints that my change might prevent unwanted behavior, since there seems to be no safe way to interrupt animations.
Rod of Discord, a few Whips, bows and Recall mirrors were tested with this, with no issues.