### PR TITLE
fix: prefer better/more correct APIs for assembly/type loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - New ambience tracks: `Beach Waves`.
   (Thanks, **@ZestyMace**!)
 - The decal system has been expanded with support for background decals. In other words, blood and impacts can now stain walls as well as floors.
+	(Assisted by **@steviegt6**!)
 - Implemented a 'camera curio system'. Subtly shifting and zooming on important areas, the system will be used to hint the player's attention towards important objects and events, increasing cinematic feel on top of all.
 - The following camera curios have been implemented:
 	- **NPCs in dialogues**;
@@ -110,6 +111,7 @@
 - Overhaul's internal chunk system is now data-oriented, with improved CPU caching and slightly reduced memory usage.
 - Overhaul's internal chunks will now be unloaded from memory when unused for some time.
 ### Fixes
+- Fixed the mod using out of date assembly type iteration APIs (Thanks, `@steviegt6`!)
 - Fixed issue [#217](https://github.com/Mirsario/TerrariaOverhaul/issues/217) (Decals may become offset or warped in rendering).
 - Fixed issue [#195](https://github.com/Mirsario/TerrariaOverhaul/issues/195) (Cutting down a tree makes things disappear for a moment).
 - Fixed issue [#252](https://github.com/Mirsario/TerrariaOverhaul/issues/252) (Spirit Flame & Mystic Coil Snake wrongfully rotated by AlwaysShowAimableWeapons).

--- a/Common/Ambience/_Environment/EnvironmentSystem.cs
+++ b/Common/Ambience/_Environment/EnvironmentSystem.cs
@@ -9,6 +9,7 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
+using Terraria.ModLoader.Core;
 using TerrariaOverhaul.Utilities.Terraria;
 using EnvironmentTag = TerrariaOverhaul.Core.Tags.Tag<TerrariaOverhaul.Common.Ambience.EnvironmentSystem>;
 
@@ -45,7 +46,7 @@ internal sealed partial class EnvironmentSystem : ModSystem
 	{
 		FillZoneBitmaskMapping(biomeTagsByMaskIndex);
 
-		foreach (var type in Assembly.GetExecutingAssembly().GetTypes()) {
+		foreach (var type in AssemblyManager.GetLoadableTypes(Mod.Code)) {
 			foreach (var method in type.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)) {
 				var attribute = method.GetCustomAttribute<EnvironmentSignalUpdaterAttribute>();
 

--- a/Core/Configuration/ConfigSystem.cs
+++ b/Core/Configuration/ConfigSystem.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Terraria.Localization;
 using Terraria.ModLoader;
+using Terraria.ModLoader.Core;
 using TerrariaOverhaul.Core.Debugging;
 
 namespace TerrariaOverhaul.Core.Configuration;
@@ -87,7 +88,7 @@ internal sealed class ConfigSystem : ModSystem
 				continue;
 			}
 
-			foreach (var type in modAssembly.GetTypes()) {
+			foreach (var type in AssemblyManager.GetLoadableTypes(modAssembly)) {
 				if (type.IsEnum) {
 					continue;
 				}

--- a/Core/Data/DataStorage.cs
+++ b/Core/Data/DataStorage.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Terraria.ModLoader.Core;
 using BitMask64 = TerrariaOverhaul.Utilities.BitMask<ulong>;
 
 namespace TerrariaOverhaul.Core.Data;
@@ -228,7 +229,7 @@ internal static class DataStorage
 
 	public static void RegisterTypesFromAssembly(Assembly assembly)
 	{
-		foreach (var type in assembly.GetTypes().Where(t => !t.IsAbstract && typeof(IComponent).IsAssignableFrom(t))) {
+		foreach (var type in AssemblyManager.GetLoadableTypes(assembly).Where(t => !t.IsAbstract && typeof(IComponent).IsAssignableFrom(t))) {
 			RegisterComponent(type);
 		}
 	}

--- a/Core/Networking/MultiplayerSystem.cs
+++ b/Core/Networking/MultiplayerSystem.cs
@@ -6,11 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
+using Terraria.ModLoader.Core;
 
 namespace TerrariaOverhaul.Core.Networking;
 
@@ -26,8 +26,8 @@ internal sealed class MultiplayerSystem : ModSystem
 	public override void Load()
 	{
 
-		foreach (var type in Assembly.GetExecutingAssembly().GetTypes().Where(t => !t.IsAbstract && t.IsSubclassOf(typeof(NetPacket)))) {
-			var instance = (NetPacket)FormatterServices.GetUninitializedObject(type);
+		foreach (var type in AssemblyManager.GetLoadableTypes(Mod.Code).Where(t => !t.IsAbstract && t.IsSubclassOf(typeof(NetPacket)))) {
+			var instance = (NetPacket)RuntimeHelpers.GetUninitializedObject(type);
 
 			instance.Id = packets.Count;
 			packetsByType[type] = instance;

--- a/Core/VideoPlayback/OgvReader.cs
+++ b/Core/VideoPlayback/OgvReader.cs
@@ -6,8 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Microsoft.Xna.Framework.Media;
 using ReLogic.Content;
@@ -85,7 +85,7 @@ internal sealed class OgvReader : IAssetReader, ILoadable
 		// Here we assemble the Video instance completely by ourselves.
 		// Good thing that we no longer have to account for different frameworks being used.
 		// - Mirsario.
-		var result = (Video)FormatterServices.GetUninitializedObject(videoType);
+		var result = (Video)RuntimeHelpers.GetUninitializedObject(videoType);
 
 		int openResult = tf_open_callbacks(dataPtr, out nint theoraPtr, callbacks);
 


### PR DESCRIPTION
Most important is `AssemblyManager.GetLoadableTypes` in place of `Assembly.GetTypes`, which was important as any mods strongly or weakly referencing TO with other weak references could crash due to TO forcing them to load types that are meant to be ignored.

I also changed `Assembly.GetExecutingAssembly` in favor of `Mod.Code` for safety where possible. It's equivalent to `Assembly.GetExecutingAssembly`, but using `Mod.Code` ensures it'll be a mod's assembly (which is what `GetLoadableTypes` is supposed to work with).

`FormatterServices.GetUninitializedObject` is obsolete, but `RuntimeHelpers.GetUninitializedObject` is still fully supporter (the former just redirects to the latter).