### PR TITLE
Fix flamethrower sound persisting after item swap

### DIFF
--- a/Common/Guns/_Overhauls/Flamethrower.cs
+++ b/Common/Guns/_Overhauls/Flamethrower.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020-2026 Mirsario & Contributors.
+// Copyright (c) 2020-2026 Mirsario & Contributors.
 // Released under the GNU General Public License 3.0.
 // See LICENSE.md for details.
 
@@ -6,6 +6,7 @@ using ReLogic.Utilities;
 using Terraria;
 using Terraria.Audio;
 using Terraria.ID;
+using Terraria.ModLoader;
 using TerrariaOverhaul.Common.Recoil;
 using TerrariaOverhaul.Core.ItemComponents;
 using TerrariaOverhaul.Core.ItemOverhauls;
@@ -14,67 +15,107 @@ namespace TerrariaOverhaul.Common.Guns;
 
 internal class Flamethrower : ItemOverhaul
 {
-	private static readonly SoundStyle FireSound = new($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Items/Guns/Flamethrower/FlamethrowerFireLoop") {
-		IsLooped = true,
-		Volume = 0.15f,
-		PitchVariance = 0.2f,
-	};
+        private static readonly SoundStyle FireSound = new($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Items/Guns/Flamethrower/FlamethrowerFireLoop") {
+                IsLooped = true,
+                Volume = 0.15f,
+                PitchVariance = 0.2f,
+        };
 
-	private SlotId soundId;
+        private SlotId soundId;
 
-	public override bool ShouldApplyItemOverhaul(Item item)
-		=> item.useAmmo == AmmoID.Gel;
+        public override bool ShouldApplyItemOverhaul(Item item)
+                => item.useAmmo == AmmoID.Gel;
 
-	public override void SetDefaults(Item item)
-	{
-		base.SetDefaults(item);
+        public override void SetDefaults(Item item)
+        {
+                base.SetDefaults(item);
 
-		//if (Guns.EnableGunSoundReplacements) {
-		//	item.UseSound = null;
-		//}
+                if (!Main.dedServ) {
+                        item.EnableComponent<ItemAimRecoil>();
+                        item.EnableComponent<ItemMuzzleflashes>(c => {
+                                c.DefaultMuzzleflashLength = (uint)(item.useTime + 1);
+                        });
+                }
+        }
 
-		if (!Main.dedServ) {
-			item.EnableComponent<ItemAimRecoil>();
-			item.EnableComponent<ItemMuzzleflashes>(c => {
-				c.DefaultMuzzleflashLength = (uint)(item.useTime + 1);
-			});
-		}
-	}
+        public override bool? UseItem(Item item, Player player)
+        {
+                if (Guns.EnableGunSoundReplacements && (!soundId.IsValid || !SoundEngine.TryGetActiveSound(soundId, out _))) {
+                        soundId = SoundEngine.PlaySound(FireSound, player.Center);
+                        player.GetModPlayer<FlamethrowerSoundTracker>().TrackSound(soundId);
+                }
 
-	public override bool? UseItem(Item item, Player player)
-	{
-		if (Guns.EnableGunSoundReplacements && !soundId.IsValid || !SoundEngine.TryGetActiveSound(soundId, out _)) {
-			soundId = SoundEngine.PlaySound(FireSound, player.Center);
-		}
+                return base.UseItem(item, player);
+        }
 
-		return base.UseItem(item, player);
-	}
+        public override void UpdateInventory(Item item, Player player)
+        {
+                base.UpdateInventory(item, player);
 
-	public override void UpdateInventory(Item item, Player player)
-	{
-		base.UpdateInventory(item, player);
+                UpdateSound(item, player);
+        }
 
-		if (Guns.EnableGunSoundReplacements && SoundEngine.TryGetActiveSound(soundId, out var activeSound)) {
-			if (player.HeldItem != item) {
-				activeSound.Stop();
+        public override void HoldItem(Item item, Player player)
+        {
+                base.HoldItem(item, player);
 
-				soundId = SlotId.Invalid;
-			}
-		}
-	}
+                UpdateSound(item, player);
+        }
 
-	public override void HoldItem(Item item, Player player)
-	{
-		base.HoldItem(item, player);
+        private void UpdateSound(Item item, Player player)
+        {
+                if (!Guns.EnableGunSoundReplacements || !soundId.IsValid || !SoundEngine.TryGetActiveSound(soundId, out var activeSound)) {
+                        return;
+                }
 
-		if (Guns.EnableGunSoundReplacements && SoundEngine.TryGetActiveSound(soundId, out var activeSound)) {
-			if (!player.ItemAnimationActive && player.itemTime <= 0) {
-				activeSound.Stop();
+                bool shouldStop =
+                        player.HeldItem != item ||              // Not holding this item
+                        !player.ItemAnimationActive ||          // Not actively using
+                        player.itemTime <= 0 ||                 // Use time expired
+                        player.dead ||                          // Dead
+                        player.frozen ||                        // Frozen
+                        player.stoned ||                        // Petrified
+                        player.webbed ||                        // Webbed
+                        player.noItems;                         // Can't use items
 
-				soundId = SlotId.Invalid;
-			} else {
-				activeSound.Position = player.Center;
-			}
-		}
-	}
+                if (shouldStop) {
+                        activeSound.Stop();
+                        soundId = SlotId.Invalid;
+                        player.GetModPlayer<FlamethrowerSoundTracker>().UntrackSound();
+                } else {
+                        activeSound.Position = player.Center;
+                }
+        }
+}
+
+[Autoload(Side = ModSide.Client)]
+internal sealed class FlamethrowerSoundTracker : ModPlayer
+{
+        private SlotId trackedSound;
+
+        public void TrackSound(SlotId soundId) => trackedSound = soundId;
+        public void UntrackSound() => trackedSound = SlotId.Invalid;
+
+        public override void PostUpdate()
+        {
+                // Safety net: stop orphaned sounds from dropped items or edge cases
+                // that UpdateInventory/HoldItem missed
+                if (!trackedSound.IsValid || !SoundEngine.TryGetActiveSound(trackedSound, out var activeSound)) {
+                        return;
+                }
+
+                bool playerIsValid =
+                        !Player.dead &&
+                        !Player.frozen &&
+                        !Player.stoned &&
+                        !Player.webbed &&
+                        !Player.noItems &&
+                        Player.ItemAnimationActive &&
+                        Player.HeldItem?.useAmmo == AmmoID.Gel;
+
+                if (!playerIsValid) {
+                        activeSound.Stop();
+                        trackedSound = SlotId.Invalid;
+                }
+        }
 }

--- a/Common/Guns/_Overhauls/Flamethrower.cs
+++ b/Common/Guns/_Overhauls/Flamethrower.cs
@@ -50,6 +50,19 @@ internal class Flamethrower : ItemOverhaul
 		return base.UseItem(item, player);
 	}
 
+	public override void UpdateInventory(Item item, Player player)
+	{
+		base.UpdateInventory(item, player);
+
+		if (Guns.EnableGunSoundReplacements && SoundEngine.TryGetActiveSound(soundId, out var activeSound)) {
+			if (player.HeldItem != item) {
+				activeSound.Stop();
+
+				soundId = SlotId.Invalid;
+			}
+		}
+	}
+
 	public override void HoldItem(Item item, Player player)
 	{
 		base.HoldItem(item, player);


### PR DESCRIPTION
Fixes #258

## Root cause

Flamethrower uses a looping  with . The sound was started in  but only stopped when  detected the animation ending. If the player swapped items mid-fire,  stopped running for the flamethrower, so the sound loop persisted forever.

## Fix

### Layer 1: Centralized  method

Consolidated all sound stop logic into a single method called from both  and . Stop conditions:

| Condition | Trigger |
|-----------|---------|
|  | Swapped to different item |
|  | Use time expired |
|  | Died |
|  | Frozen |
|  | Petrified |
|  | Webbed |
|  | Can't use items |

### Layer 2:  ModPlayer safety net

A client-side  that independently tracks the active sound slot.  acts as a final safety net, stopping orphaned sounds from:

- Dropping the item while firing (skips )
- Any edge case that bypasses /

## Files changed

- 