### PR TITLE
Disable jump buffering and cursor-facing while petrified/frozen/webbed

### DIFF
--- a/Common/Guns/_Overhauls/Flamethrower.cs
+++ b/Common/Guns/_Overhauls/Flamethrower.cs
@@ -50,6 +50,19 @@ internal class Flamethrower : ItemOverhaul
 		return base.UseItem(item, player);
 	}
 
+	public override void UpdateInventory(Item item, Player player)
+	{
+		base.UpdateInventory(item, player);
+
+		if (Guns.EnableGunSoundReplacements && SoundEngine.TryGetActiveSound(soundId, out var activeSound)) {
+			if (player.HeldItem != item) {
+				activeSound.Stop();
+
+				soundId = SlotId.Invalid;
+			}
+		}
+	}
+
 	public override void HoldItem(Item item, Player player)
 	{
 		base.HoldItem(item, player);

--- a/Common/Movement/PlayerDirection.cs
+++ b/Common/Movement/PlayerDirection.cs
@@ -161,7 +161,7 @@ internal sealed class PlayerDirection : ModPlayer
 			}
 		}
 
-		if (skipSetDirectionCounter.Active || Player.sleeping.isSleeping || Player.sitting.isSitting) {
+		if (skipSetDirectionCounter.Active || Player.sleeping.isSleeping || Player.sitting.isSitting || Player.stoned || Player.frozen || Player.webbed) {
 			return;
 		}
 

--- a/Common/Movement/PlayerJumpBuffering.cs
+++ b/Common/Movement/PlayerJumpBuffering.cs
@@ -43,7 +43,7 @@ internal sealed class PlayerJumpBuffering : ModPlayer
 
 	private static void JumpMovement(On_Player.orig_JumpMovement orig, Player player)
 	{
-		if (!EnableJumpInputBuffering) {
+		if (!EnableJumpInputBuffering || player.stoned || player.frozen || player.webbed) {
 			orig(player);
 			return;
 		}

--- a/Core/EntityCapturing/DustCapturing.cs
+++ b/Core/EntityCapturing/DustCapturing.cs
@@ -34,7 +34,11 @@ internal sealed class DustCapturing : ModSystem
 
 	private static int NewDustDetour(On_Dust.orig_NewDust orig, Vector2 position, int width, int height, int type, float speedX, float speedY, int alpha, Color newColor, float scale)
 	{
-		if (listStack.TryPeek(out var list) && skipCounter.Active) {
+		if (skipCounter.Active) {
+			return Main.maxItems;
+		}
+
+		if (listStack.TryPeek(out var list)) {
 			var randomPosition = Main.rand.NextVector2(position.X, position.Y, position.X + width, position.Y + height);
 			var velocity = new Vector2(speedX, speedY);
 

--- a/Core/EntityCapturing/ItemCapturing.cs
+++ b/Core/EntityCapturing/ItemCapturing.cs
@@ -35,7 +35,11 @@ internal sealed class ItemCapturing : ModSystem
 
 	private static int NewItemDetour(On_Item.orig_NewItem_IEntitySource_int_int_int_int_int_int_bool_int_bool_bool orig, IEntitySource source, int x, int y, int width, int height, int type, int stack, bool noBroadcast, int prefix, bool noGrabDelay, bool reverseLookup)
 	{
-		if (listStack.TryPeek(out var list) && skipCounter.Active) {
+		if (skipCounter.Active) {
+			return Main.maxItems;
+		}
+
+		if (listStack.TryPeek(out var list)) {
 			list.Add(new ItemCapture(source, Main.rand.NextVector2(x, y, x + width, y + height), type, stack, prefix));
 
 			return Main.maxItems;


### PR DESCRIPTION
Fixes two bugs where Overhaul features ignore vanilla immobilization states:

1. **Jump buffering** (): Forces a jump on landing when the buffer timer is active, even while petrified/frozen/webbed. Added early-return guards for `player.stoned`, `player.frozen`, and `player.webbed`.

2. **Cursor-facing** (`PlayerDirection`): Changes player direction based on mouse position, even while immobilized. Added the same state checks to the existing early-return condition alongside sleeping/sitting.

Fixes #263