### PR TITLE
Skip converting gores from other mods into OverhaulGore

### DIFF
--- a/Common/BloodAndGore/GoreSystem.cs
+++ b/Common/BloodAndGore/GoreSystem.cs
@@ -93,6 +93,11 @@ internal class GoreSystem : ModSystem
 				return;
 			}
 
+			// Don't convert gores from other mods.
+			if (gore.ModGore is { } modGore && modGore.Mod != Mod) {
+				return;
+			}
+
 			goreExt = ConvertGore(gore, () => Array.IndexOf(Main.gore, gore)); //TODO: Avoid this IndexOf call?
 		}
 
@@ -109,8 +114,15 @@ internal class GoreSystem : ModSystem
 		int result = orig(entitySource, position, velocity, type, scale);
 
 		if (result < Main.maxGore) {
+			// Don't convert gores from other mods.
+			var spawnedGore = Main.gore[result];
+
+			if (spawnedGore.ModGore is { } modGore && modGore.Mod != Mod) {
+				return result;
+			}
+
 			// Convert gores to a new class.
-			var goreExt = ConvertGore(Main.gore[result], () => result);
+			var goreExt = ConvertGore(spawnedGore, () => result);
 
 			// Record gores, if requested.
 			for (int i = 0; i < goreRecordingLists.Count; i++) {

--- a/Common/Guns/_Overhauls/Flamethrower.cs
+++ b/Common/Guns/_Overhauls/Flamethrower.cs
@@ -50,6 +50,19 @@ internal class Flamethrower : ItemOverhaul
 		return base.UseItem(item, player);
 	}
 
+	public override void UpdateInventory(Item item, Player player)
+	{
+		base.UpdateInventory(item, player);
+
+		if (Guns.EnableGunSoundReplacements && SoundEngine.TryGetActiveSound(soundId, out var activeSound)) {
+			if (player.HeldItem != item) {
+				activeSound.Stop();
+
+				soundId = SlotId.Invalid;
+			}
+		}
+	}
+
 	public override void HoldItem(Item item, Player player)
 	{
 		base.HoldItem(item, player);

--- a/Common/Movement/PlayerDirection.cs
+++ b/Common/Movement/PlayerDirection.cs
@@ -161,7 +161,7 @@ internal sealed class PlayerDirection : ModPlayer
 			}
 		}
 
-		if (skipSetDirectionCounter.Active || Player.sleeping.isSleeping || Player.sitting.isSitting) {
+		if (skipSetDirectionCounter.Active || Player.sleeping.isSleeping || Player.sitting.isSitting || Player.stoned || Player.frozen || Player.webbed) {
 			return;
 		}
 

--- a/Common/Movement/PlayerJumpBuffering.cs
+++ b/Common/Movement/PlayerJumpBuffering.cs
@@ -43,7 +43,7 @@ internal sealed class PlayerJumpBuffering : ModPlayer
 
 	private static void JumpMovement(On_Player.orig_JumpMovement orig, Player player)
 	{
-		if (!EnableJumpInputBuffering) {
+		if (!EnableJumpInputBuffering || player.stoned || player.frozen || player.webbed) {
 			orig(player);
 			return;
 		}

--- a/Core/EntityCapturing/DustCapturing.cs
+++ b/Core/EntityCapturing/DustCapturing.cs
@@ -34,7 +34,11 @@ internal sealed class DustCapturing : ModSystem
 
 	private static int NewDustDetour(On_Dust.orig_NewDust orig, Vector2 position, int width, int height, int type, float speedX, float speedY, int alpha, Color newColor, float scale)
 	{
-		if (listStack.TryPeek(out var list) && skipCounter.Active) {
+		if (skipCounter.Active) {
+			return Main.maxItems;
+		}
+
+		if (listStack.TryPeek(out var list)) {
 			var randomPosition = Main.rand.NextVector2(position.X, position.Y, position.X + width, position.Y + height);
 			var velocity = new Vector2(speedX, speedY);
 

--- a/Core/EntityCapturing/ItemCapturing.cs
+++ b/Core/EntityCapturing/ItemCapturing.cs
@@ -35,7 +35,11 @@ internal sealed class ItemCapturing : ModSystem
 
 	private static int NewItemDetour(On_Item.orig_NewItem_IEntitySource_int_int_int_int_int_int_bool_int_bool_bool orig, IEntitySource source, int x, int y, int width, int height, int type, int stack, bool noBroadcast, int prefix, bool noGrabDelay, bool reverseLookup)
 	{
-		if (listStack.TryPeek(out var list) && skipCounter.Active) {
+		if (skipCounter.Active) {
+			return Main.maxItems;
+		}
+
+		if (listStack.TryPeek(out var list)) {
 			list.Add(new ItemCapture(source, Main.rand.NextVector2(x, y, x + width, y + height), type, stack, prefix));
 
 			return Main.maxItems;


### PR DESCRIPTION
Overhaul's GoreSystem was converting all gores (including mod gores) into OverhaulGore, applying physics, sounds, and burning effects to them. This caused mod gores like Atmospheric Lava Mod's smoke particles to play gore hit/break sounds.

- NewGoreDetour: Return early if spawned gore belongs to another mod
- GoreUpdate: Return early if gore belongs to another mod

Fixes #264