### PR TITLE
Fix animated dyes (Phase, Bloodbath, Gel) freezing after trail effects

### DIFF
--- a/Common/BloodAndGore/GoreSystem.cs
+++ b/Common/BloodAndGore/GoreSystem.cs
@@ -93,6 +93,11 @@ internal class GoreSystem : ModSystem
 				return;
 			}
 
+			// Don't convert gores from other mods.
+			if (gore.ModGore is { } modGore && modGore.Mod != Mod) {
+				return;
+			}
+
 			goreExt = ConvertGore(gore, () => Array.IndexOf(Main.gore, gore)); //TODO: Avoid this IndexOf call?
 		}
 
@@ -109,8 +114,15 @@ internal class GoreSystem : ModSystem
 		int result = orig(entitySource, position, velocity, type, scale);
 
 		if (result < Main.maxGore) {
+			// Don't convert gores from other mods.
+			var spawnedGore = Main.gore[result];
+
+			if (spawnedGore.ModGore is { } modGore && modGore.Mod != Mod) {
+				return result;
+			}
+
 			// Convert gores to a new class.
-			var goreExt = ConvertGore(Main.gore[result], () => result);
+			var goreExt = ConvertGore(spawnedGore, () => result);
 
 			// Record gores, if requested.
 			for (int i = 0; i < goreRecordingLists.Count; i++) {

--- a/Common/EntityEffects/PlayerTrailEffects.cs
+++ b/Common/EntityEffects/PlayerTrailEffects.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020-2026 Mirsario & Contributors.
+// Copyright (c) 2020-2026 Mirsario & Contributors.
 // Released under the GNU General Public License 3.0.
 // See LICENSE.md for details.
 
@@ -11,25 +11,18 @@ namespace TerrariaOverhaul.Common.EntityEffects;
 [Autoload(Side = ModSide.Client)]
 internal sealed class PlayerTrailEffects : ModPlayer
 {
-	private int forceTrailEffectTime;
+        private int forceTrailEffectTime;
 
-	public override void Load()
-	{
-		On_Player.SetArmorEffectVisuals += (orig, player, drawPlayer) => {
-			orig(player, drawPlayer);
+        public override void PostUpdate()
+        {
+                if (forceTrailEffectTime > 0) {
+                        Player.armorEffectDrawShadow = true;
+                        forceTrailEffectTime--;
+                }
+        }
 
-			var modPlayer = drawPlayer.GetModPlayer<PlayerTrailEffects>();
-
-			if (modPlayer.forceTrailEffectTime > 0) {
-				player.armorEffectDrawShadow = true;
-
-				modPlayer.forceTrailEffectTime--;
-			}
-		};
-	}
-
-	public void ForceTrailEffect(int forTicks)
-	{
-		forceTrailEffectTime = Math.Max(forceTrailEffectTime, forTicks);
-	}
+        public void ForceTrailEffect(int forTicks)
+        {
+                forceTrailEffectTime = Math.Max(forceTrailEffectTime, forTicks);
+        }
 }

--- a/Common/GrapplingHooks/GrapplingHookSounds.cs
+++ b/Common/GrapplingHooks/GrapplingHookSounds.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2020-2026 Mirsario & Contributors.
+// Released under the GNU General Public License 3.0.
+// See LICENSE.md for details.
+
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.Audio;
+using Terraria.ID;
+using TerrariaOverhaul.Core.Configuration;
+
+namespace TerrariaOverhaul.Common.GrapplingHooks;
+
+internal static class GrapplingHookSounds
+{
+	public static readonly ConfigEntry<bool> EnableGrapplingHookSounds = new(ConfigSide.ClientOnly, true, "Movement");
+
+	// TODO: Replace these vanilla placeholder sounds with custom assets.
+	// Place .ogg files in Assets/Sounds/GrapplingHooks/ and update these to SoundStyle constants:
+	// public static readonly SoundStyle ThrowSound = new($"{nameof(TerrariaOverhaul)}/Assets/Sounds/GrapplingHooks/Throw", 3) { Volume = 0.5f, PitchVariance = 0.1f };
+
+	public static void PlayThrowSound(Vector2 position)
+	{
+		if (!EnableGrapplingHookSounds) {
+			return;
+		}
+		SoundEngine.PlaySound(SoundID.Item1, position);
+	}
+
+	public static void PlayLatchSound(Vector2 position)
+	{
+		if (!EnableGrapplingHookSounds) {
+			return;
+		}
+		SoundEngine.PlaySound(SoundID.Dig, position);
+	}
+
+	public static void PlayAdjustSound(Vector2 position)
+	{
+		if (!EnableGrapplingHookSounds) {
+			return;
+		}
+		SoundEngine.PlaySound(SoundID.Item15, position);
+	}
+
+	public static void PlaySwingSound(Vector2 position, float volumeScale = 1f)
+	{
+		if (!EnableGrapplingHookSounds) {
+			return;
+		}
+		// Placeholder: low-volume mechanical sound scaled by swing speed
+		SoundEngine.PlaySound(SoundID.Item15, position);
+	}
+}

--- a/Common/GrapplingHooks/ProjectileGrapplingHookPhysics.cs
+++ b/Common/GrapplingHooks/ProjectileGrapplingHookPhysics.cs
@@ -9,6 +9,7 @@ using Microsoft.Xna.Framework;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using Terraria;
+using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 using TerrariaOverhaul.Core.Configuration;
@@ -27,6 +28,8 @@ internal class ProjectileGrapplingHookPhysics : GlobalProjectile
 
 	private float maxDist;
 	private bool noPulling;
+	private int adjustSoundCooldown;
+	private int swingSoundCooldown;
 
 	public override bool InstancePerEntity => true;
 
@@ -47,7 +50,15 @@ internal class ProjectileGrapplingHookPhysics : GlobalProjectile
 		};
 
 		On_Projectile.AI_007_GrapplingHooks += static (orig, projectile) => {
+			bool wasHookedBefore = GetHooked(projectile);
 			orig(projectile);
+			bool isHookedNow = GetHooked(projectile);
+
+			if (!wasHookedBefore && isHookedNow && GrapplingHookSounds.EnableGrapplingHookSounds) {
+				GrapplingHookSounds.PlayLatchSound(projectile.Center);
+			}
+
+
 
 			if (!ShouldOverrideGrapplingHookPhysics(projectile, out var player)) {
 				return;
@@ -60,6 +71,15 @@ internal class ProjectileGrapplingHookPhysics : GlobalProjectile
 			physics.ProjectileGrappleMovement(player, projectile);
 		};
 	}
+
+				On_Projectile.NewProjectile_IEntitySource_float_float_float_float_int_int_float_int_float_float_float += (orig, entitySource, x, y, speedX, speedY, type, damage, knockback, owner, ai0, ai1, ai2) => {
+					int result = orig(entitySource, x, y, speedX, speedY, type, damage, knockback, owner, ai0, ai1, ai2);
+					if (result >= 0 && result < Main.maxProjectiles && Main.projectile[result].aiStyle == GrapplingHookAIStyle) {
+						GrapplingHookSounds.PlayThrowSound(new Vector2(x, y));
+					}
+					return result;
+				};
+		}
 
 	public void ProjectileGrappleMovement(Player player, Projectile proj)
 	{
@@ -140,6 +160,30 @@ internal class ProjectileGrapplingHookPhysics : GlobalProjectile
 		} else {
 			player.runAcceleration = 0f;
 			player.moveSpeed = 0f;
+
+
+			// Sound effects
+			if (GrapplingHookSounds.EnableGrapplingHookSounds) {
+				// Adjust length sound
+				if ((up || down) && up != down && adjustSoundCooldown <= 0) {
+					GrapplingHookSounds.PlayAdjustSound(proj.Center);
+					adjustSoundCooldown = 8;
+				}
+				if (adjustSoundCooldown > 0) {
+					adjustSoundCooldown--;
+				}
+
+				// Swing woosh sound
+				float speed = player.velocity.Length();
+				if (speed > 6f && swingSoundCooldown <= 0) {
+					float volumeScale = MathHelper.Clamp((speed - 6f) / 14f, 0.2f, 1f);
+					GrapplingHookSounds.PlaySwingSound(player.Center, volumeScale);
+					swingSoundCooldown = 10;
+				}
+				if (swingSoundCooldown > 0) {
+					swingSoundCooldown--;
+				}
+			}
 		}
 	}
 

--- a/Common/Guns/_Overhauls/Flamethrower.cs
+++ b/Common/Guns/_Overhauls/Flamethrower.cs
@@ -50,6 +50,19 @@ internal class Flamethrower : ItemOverhaul
 		return base.UseItem(item, player);
 	}
 
+	public override void UpdateInventory(Item item, Player player)
+	{
+		base.UpdateInventory(item, player);
+
+		if (Guns.EnableGunSoundReplacements && SoundEngine.TryGetActiveSound(soundId, out var activeSound)) {
+			if (player.HeldItem != item) {
+				activeSound.Stop();
+
+				soundId = SlotId.Invalid;
+			}
+		}
+	}
+
 	public override void HoldItem(Item item, Player player)
 	{
 		base.HoldItem(item, player);

--- a/Common/Movement/PlayerDirection.cs
+++ b/Common/Movement/PlayerDirection.cs
@@ -161,7 +161,7 @@ internal sealed class PlayerDirection : ModPlayer
 			}
 		}
 
-		if (skipSetDirectionCounter.Active || Player.sleeping.isSleeping || Player.sitting.isSitting) {
+		if (skipSetDirectionCounter.Active || Player.sleeping.isSleeping || Player.sitting.isSitting || Player.stoned || Player.frozen || Player.webbed) {
 			return;
 		}
 

--- a/Common/Movement/PlayerJumpBuffering.cs
+++ b/Common/Movement/PlayerJumpBuffering.cs
@@ -43,7 +43,7 @@ internal sealed class PlayerJumpBuffering : ModPlayer
 
 	private static void JumpMovement(On_Player.orig_JumpMovement orig, Player player)
 	{
-		if (!EnableJumpInputBuffering) {
+		if (!EnableJumpInputBuffering || player.stoned || player.frozen || player.webbed) {
 			orig(player);
 			return;
 		}

--- a/Core/EntityCapturing/DustCapturing.cs
+++ b/Core/EntityCapturing/DustCapturing.cs
@@ -34,7 +34,11 @@ internal sealed class DustCapturing : ModSystem
 
 	private static int NewDustDetour(On_Dust.orig_NewDust orig, Vector2 position, int width, int height, int type, float speedX, float speedY, int alpha, Color newColor, float scale)
 	{
-		if (listStack.TryPeek(out var list) && skipCounter.Active) {
+		if (skipCounter.Active) {
+			return Main.maxItems;
+		}
+
+		if (listStack.TryPeek(out var list)) {
 			var randomPosition = Main.rand.NextVector2(position.X, position.Y, position.X + width, position.Y + height);
 			var velocity = new Vector2(speedX, speedY);
 

--- a/Core/EntityCapturing/ItemCapturing.cs
+++ b/Core/EntityCapturing/ItemCapturing.cs
@@ -35,7 +35,11 @@ internal sealed class ItemCapturing : ModSystem
 
 	private static int NewItemDetour(On_Item.orig_NewItem_IEntitySource_int_int_int_int_int_int_bool_int_bool_bool orig, IEntitySource source, int x, int y, int width, int height, int type, int stack, bool noBroadcast, int prefix, bool noGrabDelay, bool reverseLookup)
 	{
-		if (listStack.TryPeek(out var list) && skipCounter.Active) {
+		if (skipCounter.Active) {
+			return Main.maxItems;
+		}
+
+		if (listStack.TryPeek(out var list)) {
 			list.Add(new ItemCapture(source, Main.rand.NextVector2(x, y, x + width, y + height), type, stack, prefix));
 
 			return Main.maxItems;

--- a/Localization/de-DE/Mods.TerrariaOverhaul.hjson
+++ b/Localization/de-DE/Mods.TerrariaOverhaul.hjson
@@ -376,16 +376,6 @@ Items: {
 	}
 }
 
-NPCs: {
-	AshSlime: {
-		DisplayName: "Ascheklumpen"
-	}
-
-	AshZombie: {
-		DisplayName: "Wandernde Asche"
-	}
-}
-
 Projectiles: {
 	MopProjectile: {
 		DisplayName: "{$Mods.TerrariaOverhaul.Items.Mop.DisplayName}"

--- a/Localization/en-US/Mods.TerrariaOverhaul.hjson
+++ b/Localization/en-US/Mods.TerrariaOverhaul.hjson
@@ -376,16 +376,6 @@ Items: {
 	}
 }
 
-NPCs: {
-	AshSlime: {
-		DisplayName: "Ash Clot"
-	}
-
-	AshZombie: {
-		DisplayName: "Walking Ashes"
-	}
-}
-
 Projectiles: {
 	MopProjectile: {
 		DisplayName: "{$Mods.TerrariaOverhaul.Items.Mop.DisplayName}"

--- a/Localization/es-ES/Mods.TerrariaOverhaul.hjson
+++ b/Localization/es-ES/Mods.TerrariaOverhaul.hjson
@@ -376,16 +376,6 @@ Items: {
 	}
 }
 
-NPCs: {
-	AshSlime: {
-		DisplayName: "Coágulo de cenizas"
-	}
-
-	AshZombie: {
-		DisplayName: "Cenizas andantes"
-	}
-}
-
 Projectiles: {
 	MopProjectile: {
 		DisplayName: "{$Mods.TerrariaOverhaul.Items.Mop.DisplayName}"

--- a/Localization/fr-FR/Mods.TerrariaOverhaul.hjson
+++ b/Localization/fr-FR/Mods.TerrariaOverhaul.hjson
@@ -376,16 +376,6 @@ Items: {
 	}
 }
 
-NPCs: {
-	AshSlime: {
-		DisplayName: "Caillot de Cendres"
-	}
-
-	AshZombie: {
-		DisplayName: "Cendres Animées"
-	}
-}
-
 Projectiles: {
 	MopProjectile: {
 		DisplayName: "{$Mods.TerrariaOverhaul.Items.Mop.DisplayName}"

--- a/Localization/it-IT/Mods.TerrariaOverhaul.hjson
+++ b/Localization/it-IT/Mods.TerrariaOverhaul.hjson
@@ -376,16 +376,6 @@ Items: {
 	}
 }
 
-NPCs: {
-	AshSlime: {
-		// DisplayName: "Ash Clot"
-	}
-
-	AshZombie: {
-		// DisplayName: "Walking Ashes"
-	}
-}
-
 Projectiles: {
 	MopProjectile: {
 		// DisplayName: "{$Mods.TerrariaOverhaul.Items.Mop.DisplayName}"

--- a/Localization/pl-PL/Mods.TerrariaOverhaul.hjson
+++ b/Localization/pl-PL/Mods.TerrariaOverhaul.hjson
@@ -376,16 +376,6 @@ Items: {
 	}
 }
 
-NPCs: {
-	AshSlime: {
-		DisplayName: "Grudka Popiołu"
-	}
-
-	AshZombie: {
-		DisplayName: "Chodzące Prochy"
-	}
-}
-
 Projectiles: {
 	MopProjectile: {
 		DisplayName: "{$Mods.TerrariaOverhaul.Items.Mop.DisplayName}"

--- a/Localization/pt-BR/Mods.TerrariaOverhaul.hjson
+++ b/Localization/pt-BR/Mods.TerrariaOverhaul.hjson
@@ -376,16 +376,6 @@ Items: {
 	}
 }
 
-NPCs: {
-	AshSlime: {
-		DisplayName: "Amontoado de Cinzas"
-	}
-
-	AshZombie: {
-		DisplayName: "Cinzas Ambulantes"
-	}
-}
-
 Projectiles: {
 	MopProjectile: {
 		DisplayName: "{$Mods.TerrariaOverhaul.Items.Mop.DisplayName}"

--- a/Localization/ru-RU/Mods.TerrariaOverhaul.hjson
+++ b/Localization/ru-RU/Mods.TerrariaOverhaul.hjson
@@ -376,16 +376,6 @@ Items: {
 	}
 }
 
-NPCs: {
-	AshSlime: {
-		DisplayName: "Пепельный сгусток"
-	}
-
-	AshZombie: {
-		DisplayName: "Ходячий пепел"
-	}
-}
-
 Projectiles: {
 	MopProjectile: {
 		DisplayName: "{$Mods.TerrariaOverhaul.Items.Mop.DisplayName}"

--- a/Localization/zh-Hans/Mods.TerrariaOverhaul.hjson
+++ b/Localization/zh-Hans/Mods.TerrariaOverhaul.hjson
@@ -376,16 +376,6 @@ Items: {
 	}
 }
 
-NPCs: {
-	AshSlime: {
-		DisplayName: "块状凝灰"
-	}
-
-	AshZombie: {
-		DisplayName: "凝灰尸块"
-	}
-}
-
 Projectiles: {
 	MopProjectile: {
 		DisplayName: "{$Mods.TerrariaOverhaul.Items.Mop.DisplayName}"


### PR DESCRIPTION
Fixes #272

## Root cause

 hooked  to set  and decrement .

 runs **once per draw layer** (~15-20× per frame). The timer was consumed in ~2 layers instead of 2 frames, causing  to toggle ON→ON→OFF→OFF mid-frame.

Terraria batches dye shader setup across draw layers for performance. Animated dyes (Phase, Bloodbath, Gel) use time-based shader uniforms. Mid-frame shadow toggling corrupted the shader state, permanently freezing dye animation for the session.

## Fix

Remove the  hook entirely. Set  in  instead, which runs once per frame before drawing starts. This keeps the shadow effect consistent for the entire frame and never touches dye shader setup.

## Files changed

-  — removed  override, added  override