### PR TITLE
Fix footsteps playing while climbing ropes and grappling

### DIFF
--- a/Common/Bosses/DestroyerRework.cs
+++ b/Common/Bosses/DestroyerRework.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) 2020-2026 Mirsario & Contributors.
+// Copyright (c) 2020-2026 Mirsario & Contributors.
 // Released under the GNU General Public License 3.0.
 // See LICENSE.md for details.
 
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.Audio;
@@ -17,179 +18,158 @@ namespace TerrariaOverhaul.Common.Bosses;
 
 internal sealed class DestroyerRework : GlobalNPC
 {
-	private const string BaseModTexturePath = "Assets/Textures/Bosses";
+        private const string BaseModTexturePath = "Assets/Textures/Bosses";
 
-	// Audio & Screenshake
-	public static readonly ConfigEntry<bool> EnableDestroyerEffects = new(ConfigSide.ClientOnly, true, "Bosses");
-	// Sprite Swap & Size Increase.
-	public static readonly ConfigEntry<bool> EnableDestroyerMakeover = new(ConfigSide.Both, true, "Bosses");
+        // Audio & Screenshake
+        public static readonly ConfigEntry<bool> EnableDestroyerEffects = new(ConfigSide.ClientOnly, true, "Bosses");
+        // Sprite Swap & Size Increase.
+        public static readonly ConfigEntry<bool> EnableDestroyerMakeover = new(ConfigSide.Both, true, "Bosses");
 
-	private static bool spriteSwapActive;
+        private static bool spriteSwapActive;
 
-	public override bool AppliesToEntity(NPC npc, bool lateInstantiation)
-	{
-		return npc.type is NPCID.TheDestroyer or NPCID.TheDestroyerBody or NPCID.TheDestroyerTail;
-	}
+        public override bool AppliesToEntity(NPC npc, bool lateInstantiation)
+        {
+                return npc.type is NPCID.TheDestroyer or NPCID.TheDestroyerBody or NPCID.TheDestroyerTail;
+        }
 
-	public override void SetDefaults(NPC npc)
-	{
-		UpdateSpriteSwap(Mod, unloading: false);
+        public override void SetDefaults(NPC npc)
+        {
+                UpdateSpriteSwap(Mod, unloading: false);
 
-		if (EnableDestroyerMakeover) {
-			npc.width = 64;
-			npc.height = 64;
-		}
+                if (EnableDestroyerMakeover) {
+                        // Preserve hitbox center when resizing to prevent misalignment
+                        Vector2 oldCenter = npc.Center;
+                        npc.width = 64;
+                        npc.height = 64;
+                        npc.Center = oldCenter;
+                }
 
-		if (!EnableDestroyerEffects) {
-			return;
-		}
+                if (!EnableDestroyerEffects) {
+                        return;
+                }
 
-		var wormPart = npc.type switch {
-			NPCID.TheDestroyer => NpcWormEffects.PartType.Head,
-			NPCID.TheDestroyerTail => NpcWormEffects.PartType.Tail,
-			_ => NpcWormEffects.PartType.Body,
-		};
+                var wormPart = npc.type switch {
+                        NPCID.TheDestroyer => NpcWormEffects.PartType.Head,
+                        NPCID.TheDestroyerTail => NpcWormEffects.PartType.Tail,
+                        _ => NpcWormEffects.PartType.Body,
+                };
 
-		if (wormPart == NpcWormEffects.PartType.Head && npc.TryGetGlobalNPC(out NpcAudioEffects audioEffects)) {
-			audioEffects.Data = new NpcAudioEffects.EffectData {
-				// Approach
-				ApproachSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/MonsterScream") {
-					Volume = 0.50f,
-					PitchVariance = 0.25f,
-					Identifier = "TheDestroyer_Voice",
-					SoundLimitBehavior = SoundLimitBehavior.ReplaceOldest,
-				},
-				ApproachScreenShake = new ScreenShake {
-					Power = 0.75f,
-					Range = 1384f,
-					LengthInSeconds = 2.0f,
-					UniqueId = "TheDestroyer_Approach",
-				},
-				// Movement
-				MovementSoundVelocityPitching = (2.5f, 10f, -0.50f, 0.50f),
-				MovementSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/DestroyerRumbleLoop") {
-					Volume = 0.525f,
-					IsLooped = true,
-					Identifier = "TheDestroyer_Movement",
-				},
-				// Random
-				RandomSoundCooldown = (45, 60 * 10),
-				RandomSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/RoboticScream1") {
-					Volume = 0.85f,
-					PitchVariance = 0.25f,
-					Identifier = "TheDestroyer_Voice",
-					SoundLimitBehavior = SoundLimitBehavior.ReplaceOldest,
-				},
-			};
-		}
+                if (wormPart == NpcWormEffects.PartType.Head && npc.TryGetGlobalNPC(out NpcAudioEffects audioEffects)) {
+                        audioEffects.Data = new NpcAudioEffects.EffectData {
+                                // Approach
+                                ApproachSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/MonsterScream") {
+                                        Volume = 0.50f,
+                                        PitchVariance = 0.25f,
+                                        Identifier = "TheDestroyer_Voice",
+                                        SoundLimitBehavior = SoundLimitBehavior.ReplaceOldest,
+                                },
+                                ApproachScreenShake = new ScreenShake {
+                                        Power = 0.75f,
+                                        Range = 1384f,
+                                        LengthInSeconds = 2.0f,
+                                        UniqueId = "TheDestroyer_Approach",
+                                },
+                                // Movement
+                                MovementSoundVelocityPitching = (2.5f, 10f, -0.50f, 0.50f),
+                                MovementSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/DestroyerRumbleLoop") {
+                                        Volume = 0.525f,
+                                        IsLooped = true,
+                                        Identifier = "TheDestroyer_Movement",
+                                },
+                                // Random
+                                RandomSoundCooldown = (45, 60 * 10),
+                                RandomSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/RoboticScream1") {
+                                        Volume = 0.85f,
+                                        PitchVariance = 0.25f,
+                                        Identifier = "TheDestroyer_Voice",
+                                        SoundLimitBehavior = SoundLimitBehavior.ReplaceOldest,
+                                },
+                        };
+                }
 
-		if (npc.TryGetGlobalNPC(out NpcWormEffects wormEffects)) {
-			wormEffects.Data = new NpcWormEffects.EffectData {
-				Type = wormPart,
-				// Surfacing
-				SurfacingScreenShake = new ScreenShake {
-					Power = 0.40f,
-					Range = 1024f,
-					LengthInSeconds = 0.5f,
-					UniqueId = $"TheDestroyer_{npc.whoAmI}",
-				},
-				DebrisStyle = new() {
-					RangeInPixels = 64f,
-				},
-			};
-			npc.HitSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/MetalNPCHitSound") {
-				Pitch = -0.5f,
-				PitchVariance = 0.3f,
-			};
+                if (npc.TryGetGlobalNPC(out NpcWormEffects wormEffects)) {
+                        wormEffects.Data = new NpcWormEffects.EffectData {
+                                Type = wormPart,
+                                // Surfacing
+                                SurfacingScreenShake = new ScreenShake {
+                                        Power = 0.40f,
+                                        Range = 1024f,
+                                        LengthInSeconds = 0.5f,
+                                        UniqueId = $"TheDestroyer_{npc.whoAmI}",
+                                },
+                                DebrisStyle = new() {
+                                        RangeInPixels = 64f,
+                                },
+                        };
+                        npc.HitSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/MetalNPCHitSound") {
+                                Pitch = -0.5f,
+                                PitchVariance = 0.3f,
+                        };
 
-			npc.DeathSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/MetalNPCDeathSound") {
-				Pitch = 0.5f,
-				PitchVariance = 0.3f,
-			};
-		}
-	}
+                        npc.DeathSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/MetalNPCDeathSound") {
+                                Pitch = 0.5f,
+                                PitchVariance = 0.3f,
+                        };
+                }
+        }
 
-	public override void Unload()
-	{
-		UpdateSpriteSwap(Mod, unloading: true);
-	}
+        public override void Unload()
+        {
+                UpdateSpriteSwap(Mod, unloading: true);
+        }
 
-	public override bool PreAI(NPC npc)
-	{
-		if (EnableDestroyerMakeover && spriteSwapActive) {
-			// This scale is applied to modify the distance between the worm's joints.
-			npc.scale = 1.75f;
-		}
+        public override bool PreAI(NPC npc)
+        {
+                if (EnableDestroyerMakeover && spriteSwapActive) {
+                        // Preserve center when scaling to prevent hitbox drift
+                        Vector2 oldCenter = npc.Center;
+                        npc.scale = 1.75f;
+                        npc.Center = oldCenter;
+                }
 
-		return true;
-	}
+                return true;
+        }
 
-	public override void PostAI(NPC npc)
-	{
-		if (EnableDestroyerMakeover && spriteSwapActive) {
-			npc.scale = 1.00f;
-		}
-	}
+        public override void PostAI(NPC npc)
+        {
+                if (EnableDestroyerMakeover && spriteSwapActive) {
+                        // Preserve center when resetting scale
+                        Vector2 oldCenter = npc.Center;
+                        npc.scale = 1.00f;
+                        npc.Center = oldCenter;
+                }
+        }
 
-	private static bool? UpdateSpriteSwap(Mod mod, bool unloading)
-	{
-		if (Main.dedServ) {
-			return null;
-		}
+        private static bool? UpdateSpriteSwap(Mod mod, bool unloading)
+        {
+                if (Main.dedServ) {
+                        return null;
+                }
 
-		bool shouldBeActive = !unloading && EnableDestroyerMakeover;
+                bool shouldBeActive = !unloading && EnableDestroyerMakeover;
 
-		if (spriteSwapActive != shouldBeActive) {
-			if (shouldBeActive) {
-				TextureAssets.Npc[NPCID.TheDestroyer] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyer");
-				TextureAssets.Npc[NPCID.TheDestroyerBody] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyerBody");
-				TextureAssets.Npc[NPCID.TheDestroyerTail] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyerTail");
-				TextureAssets.Dest[0] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyer_Glow");
-				TextureAssets.Dest[1] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyerBody_Glow");
-				TextureAssets.Dest[2] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyerTail_Glow");
-				TextureAssets.Gore[156] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyerGore");
-			} else {
-				TextureAssets.Npc[NPCID.TheDestroyer] = Main.Assets.Request<Texture2D>($"Images/NPC_{NPCID.TheDestroyer}");
-				TextureAssets.Npc[NPCID.TheDestroyerBody] = Main.Assets.Request<Texture2D>($"Images/NPC_{NPCID.TheDestroyerBody}");
-				TextureAssets.Npc[NPCID.TheDestroyerTail] = Main.Assets.Request<Texture2D>($"Images/NPC_{NPCID.TheDestroyerTail}");
-				TextureAssets.Dest[0] = Main.Assets.Request<Texture2D>($"Images/Dest1");
-				TextureAssets.Dest[1] = Main.Assets.Request<Texture2D>($"Images/Dest2");
-				TextureAssets.Dest[2] = Main.Assets.Request<Texture2D>($"Images/Dest3");
-				TextureAssets.Gore[156] = Main.Assets.Request<Texture2D>($"Images/Gore_156");
-			}
+                if (spriteSwapActive != shouldBeActive) {
+                        if (shouldBeActive) {
+                                TextureAssets.Npc[NPCID.TheDestroyer] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyer");
+                                TextureAssets.Npc[NPCID.TheDestroyerBody] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyerBody");
+                                TextureAssets.Npc[NPCID.TheDestroyerTail] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyerTail");
+                                TextureAssets.Dest[0] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyer_Glow");
+                                TextureAssets.Dest[1] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyerBody_Glow");
+                                TextureAssets.Dest[2] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyerTail_Glow");
+                                TextureAssets.Gore[156] = mod.Assets.Request<Texture2D>($"{BaseModTexturePath}/TheDestroyerGore");
+                        } else {
+                                TextureAssets.Npc[NPCID.TheDestroyer] = Main.Assets.Request<Texture2D>($"Images/NPC_{NPCID.TheDestroyer}");
+                                TextureAssets.Npc[NPCID.TheDestroyerBody] = Main.Assets.Request<Texture2D>($"Images/NPC_{NPCID.TheDestroyerBody}");
+                                TextureAssets.Npc[NPCID.TheDestroyerTail] = Main.Assets.Request<Texture2D>($"Images/NPC_{NPCID.TheDestroyerTail}");
+                                TextureAssets.Dest[0] = Main.Assets.Request<Texture2D>($"Images/Dest1");
+                                TextureAssets.Dest[1] = Main.Assets.Request<Texture2D>($"Images/Dest2");
+                                TextureAssets.Dest[2] = Main.Assets.Request<Texture2D>($"Images/Dest3");
+                                TextureAssets.Gore[156] = Main.Assets.Request<Texture2D>($"Images/Gore_156");
+                        }
 
-			return spriteSwapActive = shouldBeActive;
-		}
+                        return spriteSwapActive = shouldBeActive;
+                }
 
-		return null;
-	}
+                return null;
+        }
 }
-
-/*public sealed class ProbeSoundRework : GlobalNPC
-{
-	public override bool AppliesToEntity(NPC npc, bool lateInstantiation) => npc.type is NPCID.Probe;
-
-	public override void SetDefaults(NPC npc)
-	{
-		npc.HitSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/MetalNPCHitSound") {
-			Pitch = 0.5f,
-			PitchVariance = 0.3f,
-		};
-		npc.DeathSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/MetalNPCDeathSound") {
-			Pitch = 0.5f,
-			PitchVariance = 0.3f,
-		};
-	}
-
-	public override void PostAI(NPC npc)
-	{
-		if (npc.active) {
-			if (npc.ai[0] % 180 == 0) {
-				SoundEngine.PlaySound(new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Bosses/MetalNPCIdleSound") {
-					MaxInstances = 3,
-					PitchVariance = 0.1f,
-				}, npc.position);
-			}
-		}
-	}
-}*/

--- a/Common/Footsteps/PlayerFootsteps.cs
+++ b/Common/Footsteps/PlayerFootsteps.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020-2026 Mirsario & Contributors.
+// Copyright (c) 2020-2026 Mirsario & Contributors.
 // Released under the GNU General Public License 3.0.
 // See LICENSE.md for details.
 
@@ -16,85 +16,90 @@ namespace TerrariaOverhaul.Common.Footsteps;
 
 internal sealed class PlayerFootsteps : ModPlayer
 {
-	public static readonly ConfigEntry<bool> EnablePlayerFootsteps = new(ConfigSide.ClientOnly, true, "Ambience");
+        public static readonly ConfigEntry<bool> EnablePlayerFootsteps = new(ConfigSide.ClientOnly, true, "Ambience");
 
-	private const uint FootstepCooldown = 5;
+        private const uint FootstepCooldown = 5;
 
-	private byte stepState;
-	private uint lastNormalStepTick;
-	private uint lastSpecialStepTick;
-	private bool bouncedThisFrame;
+        private byte stepState;
+        private uint lastNormalStepTick;
+        private uint lastSpecialStepTick;
+        private bool bouncedThisFrame;
 
-	public override void Load()
-	{
-		IL_Player.TryBouncingBlocks += TryBouncingBlocksInjection;
-	}
+        public override void Load()
+        {
+                IL_Player.TryBouncingBlocks += TryBouncingBlocksInjection;
+        }
 
-	public override void PostItemCheck()
-	{
-		UpdateFootsteps();
-		bouncedThisFrame = false;
-	}
+        public override void PostItemCheck()
+        {
+                UpdateFootsteps();
+                bouncedThisFrame = false;
+        }
 
-	private static void TryBouncingBlocksInjection(ILContext context)
-	{
-		var il = new ILCursor(context);
+        private static void TryBouncingBlocksInjection(ILContext context)
+        {
+                var il = new ILCursor(context);
 
-		// Match before 'if (controlJump)'
-		il.GotoNext(
-			MoveType.Before
-			, i => i.MatchLdarg0()
-			, i => i.MatchLdfld(typeof(Player), nameof(Player.controlJump))
-		);
-		il.Index++;
-		ILUtils.HijackIncomingLabels(il);
+                // Match before 'if (controlJump)'
+                il.GotoNext(
+                        MoveType.Before
+                        , i => i.MatchLdarg0()
+                        , i => i.MatchLdfld(typeof(Player), nameof(Player.controlJump))
+                );
+                il.Index++;
+                ILUtils.HijackIncomingLabels(il);
 
-		il.Emit(OpCodes.Ldarg_0);
-		il.EmitDelegate(static (Player p) => {
-			if (p.TryGetModPlayer(out PlayerFootsteps footsteps))
-				footsteps.bouncedThisFrame = true;
-		});
-	}
+                il.Emit(OpCodes.Ldarg_0);
+                il.EmitDelegate(static (Player p) => {
+                        if (p.TryGetModPlayer(out PlayerFootsteps footsteps))
+                                footsteps.bouncedThisFrame = true;
+                });
+        }
 
-	private void UpdateFootsteps()
-	{
-		if (Main.dedServ || !EnablePlayerFootsteps) {
-			return;
-		}
+        private void UpdateFootsteps()
+        {
+                if (Main.dedServ || !EnablePlayerFootsteps) {
+                        return;
+                }
 
-		bool onGround = Player.OnGround();
-		bool wasOnGround = Player.WasOnGround();
-		int legFrame = Player.legFrame.Y / Player.legFrame.Height;
+                // Suppress footsteps while climbing ropes, using Overhaul climbing, or grappling
+                if (Player.pulley || Player.GetModPlayer<PlayerClimbing>().IsClimbing || Player.EnumerateGrapplingHooks().Any()) {
+                        return;
+                }
 
-		FootstepType? footstepType = null;
+                bool onGround = Player.OnGround();
+                bool wasOnGround = Player.WasOnGround();
+                int legFrame = Player.legFrame.Y / Player.legFrame.Height;
 
-		if (onGround != wasOnGround || bouncedThisFrame) {
-			if (!onGround || Player.controlJump) {
-				footstepType = FootstepType.Jump;
-			} else {
-				footstepType = FootstepType.Land;
-			}
-		} else if (onGround) {
-			footstepType = FootstepType.Default;
-		}
+                FootstepType? footstepType = null;
 
-		if (footstepType.HasValue && (footstepType.Value != FootstepType.Default || stepState == 1 && (legFrame == 16 || legFrame == 17) || stepState == 0 && (legFrame == 9 || legFrame == 10))) {
-			uint tick = Main.GameUpdateCount;
-			ref uint lastStep = ref (footstepType.Value == FootstepType.Default ? ref lastNormalStepTick : ref lastSpecialStepTick);
-			var movement = Player.GetModPlayer<PlayerMovement>();
+                if (onGround != wasOnGround || bouncedThisFrame) {
+                        if (!onGround || Player.controlJump) {
+                                footstepType = FootstepType.Jump;
+                        } else {
+                                footstepType = FootstepType.Land;
+                        }
+                } else if (onGround) {
+                        footstepType = FootstepType.Default;
+                }
 
-			if ((tick - lastStep) > FootstepCooldown && FootstepSystem.Footstep(new() {
-				Kind = footstepType.Value,
-				Hitbox = Player.Hitbox,
-				Velocity = (Player.velocity, movement.SelectVelocity(3, (a, b) => a.Y > b.Y)),
-			})) {
-				stepState = (byte)(stepState == 0 ? 1 : 0);
-				lastStep = tick;
-			}
-		}
+                if (footstepType.HasValue && (footstepType.Value != FootstepType.Default || stepState == 1 && (legFrame == 16 || legFrame == 17) || stepState == 0 && (legFrame == 9 || legFrame == 10))) {
+                        uint tick = Main.GameUpdateCount;
+                        ref uint lastStep = ref (footstepType.Value == FootstepType.Default ? ref lastNormalStepTick : ref lastSpecialStepTick);
+                        var movement = Player.GetModPlayer<PlayerMovement>();
 
-		if (!onGround || legFrame == 0) {
-			stepState = 0;
-		}
-	}
+                        if ((tick - lastStep) > FootstepCooldown && FootstepSystem.Footstep(new() {
+                                Kind = footstepType.Value,
+                                Hitbox = Player.Hitbox,
+                                Velocity = (Player.velocity, movement.SelectVelocity(3, (a, b) => a.Y > b.Y)),
+                        })) {
+                                stepState = (byte)(stepState == 0 ? 1 : 0);
+                                lastStep = tick;
+                        }
+                }
+
+                if (!onGround || legFrame == 0) {
+                        stepState = 0;
+                }
+        }
 }

--- a/Common/Guns/_Overhauls/Flamethrower.cs
+++ b/Common/Guns/_Overhauls/Flamethrower.cs
@@ -50,6 +50,19 @@ internal class Flamethrower : ItemOverhaul
 		return base.UseItem(item, player);
 	}
 
+	public override void UpdateInventory(Item item, Player player)
+	{
+		base.UpdateInventory(item, player);
+
+		if (Guns.EnableGunSoundReplacements && SoundEngine.TryGetActiveSound(soundId, out var activeSound)) {
+			if (player.HeldItem != item) {
+				activeSound.Stop();
+
+				soundId = SlotId.Invalid;
+			}
+		}
+	}
+
 	public override void HoldItem(Item item, Player player)
 	{
 		base.HoldItem(item, player);

--- a/Core/EntityCapturing/DustCapturing.cs
+++ b/Core/EntityCapturing/DustCapturing.cs
@@ -34,7 +34,11 @@ internal sealed class DustCapturing : ModSystem
 
 	private static int NewDustDetour(On_Dust.orig_NewDust orig, Vector2 position, int width, int height, int type, float speedX, float speedY, int alpha, Color newColor, float scale)
 	{
-		if (listStack.TryPeek(out var list) && skipCounter.Active) {
+		if (skipCounter.Active) {
+			return Main.maxItems;
+		}
+
+		if (listStack.TryPeek(out var list)) {
 			var randomPosition = Main.rand.NextVector2(position.X, position.Y, position.X + width, position.Y + height);
 			var velocity = new Vector2(speedX, speedY);
 

--- a/Core/EntityCapturing/ItemCapturing.cs
+++ b/Core/EntityCapturing/ItemCapturing.cs
@@ -35,7 +35,11 @@ internal sealed class ItemCapturing : ModSystem
 
 	private static int NewItemDetour(On_Item.orig_NewItem_IEntitySource_int_int_int_int_int_int_bool_int_bool_bool orig, IEntitySource source, int x, int y, int width, int height, int type, int stack, bool noBroadcast, int prefix, bool noGrabDelay, bool reverseLookup)
 	{
-		if (listStack.TryPeek(out var list) && skipCounter.Active) {
+		if (skipCounter.Active) {
+			return Main.maxItems;
+		}
+
+		if (listStack.TryPeek(out var list)) {
 			list.Add(new ItemCapture(source, Main.rand.NextVector2(x, y, x + width, y + height), type, stack, prefix));
 
 			return Main.maxItems;


### PR DESCRIPTION
Fixes #279

PlayerFootsteps.UpdateFootsteps() was not checking if the player was climbing ropes (Player.pulley), using Overhaul's climbing system (PlayerClimbing.IsClimbing), or grappling. This caused footstep sounds to play continuously while the player was on ropes, climbing walls, or swinging from hooks.

Fix: Add an early return in UpdateFootsteps() when any of these movement states are active.

**File:** Common/Footsteps/PlayerFootsteps.cs